### PR TITLE
Set the global JavaScript engine to :em

### DIFF
--- a/lib/ember_script-rails.rb
+++ b/lib/ember_script-rails.rb
@@ -1,3 +1,4 @@
 require 'ember_script'
 require 'ember_script/rails/version'
 require 'ember_script/rails/engine'
+require 'ember_script/rails/railtie'

--- a/lib/ember_script/rails/engine.rb
+++ b/lib/ember_script/rails/engine.rb
@@ -6,6 +6,7 @@ module EmberScript
       initializer "ember_script.setup", :after => :'load_environment_config', :group => :all do |app|
         if app.config.assets.enabled || ::Rails::VERSION::MAJOR == 4
           app.assets.register_engine '.em', EmberScript::EmberScriptTemplate
+          app.assets.register_engine '.js.em', EmberScript::EmberScriptTemplate
         end
       end
     end

--- a/lib/ember_script/rails/railtie.rb
+++ b/lib/ember_script/rails/railtie.rb
@@ -1,0 +1,7 @@
+require 'rails/railtie'
+
+module EmberScript::Rails
+  class Railtie < ::Rails::Railtie
+    config.app_generators.javascript_engine :em
+  end
+end


### PR DESCRIPTION
Add `EmberScript::Rails::Railtie`, which sets the app_generators.javascript_engine to `:em` and defaults to
using EmberScript as the primary generator for JavaScript assets. Paves the way for [EmberScript generators in ember-rails](https://github.com/emberjs/ember-rails/pull/296).

A known issue is that if you include `ember_script-rails` _without_ `ember-rails`, you may experience the javascript-engine being defaulted to `:em` for things like default controller JS files. But I have no idea why you'd do this in the first place. Let us know if this causes issues, as including the gem would now be opting in to this generator type override.
