### PR TITLE
Depend on Railties instead of Rails

### DIFF
--- a/ember_script-rails.gemspec
+++ b/ember_script-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "ember_script", ">= 0.0.4"
-  gem.add_dependency "rails"
+  gem.add_dependency "railties"
 
   gem.add_development_dependency "bundler", [">= 1.2.2"]
   gem.add_development_dependency "appraisal"

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "~> 3.1"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
-  remote: /Users/ghempton/projects/oss/ember-script-rails
+  remote: ../
   specs:
     ember_script-rails (0.0.3)
       ember_script (>= 0.0.4)
-      rails
+      railties
 
 GEM
   remote: https://rubygems.org/
@@ -45,10 +45,9 @@ GEM
       ember_script-source (>= 0.0.2)
       execjs
       tilt
-    ember_script-source (0.0.8)
+    ember_script-source (0.0.14)
     erubis (2.7.0)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
+    execjs (2.2.2)
     hike (1.2.3)
     i18n (0.6.1)
     journey (1.0.4)

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0"
-gem "activerecord-deprecated_finders", :git=>"https://github.com/rails/activerecord-deprecated_finders.git"
+gem "activerecord-deprecated_finders", :git => "https://github.com/rails/activerecord-deprecated_finders.git"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails4.gemfile.lock
+++ b/gemfiles/rails4.gemfile.lock
@@ -5,11 +5,11 @@ GIT
     activerecord-deprecated_finders (1.0.3)
 
 PATH
-  remote: /Users/ghempton/projects/oss/ember-script-rails
+  remote: ../
   specs:
     ember_script-rails (0.0.3)
       ember_script (>= 0.0.4)
-      rails
+      railties
 
 GEM
   remote: https://rubygems.org/
@@ -48,10 +48,9 @@ GEM
       ember_script-source (>= 0.0.2)
       execjs
       tilt
-    ember_script-source (0.0.8)
+    ember_script-source (0.0.14)
     erubis (2.7.0)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
+    execjs (2.2.2)
     hike (1.2.3)
     i18n (0.6.4)
     mail (2.5.4)


### PR DESCRIPTION
ember_script-rails does not need to depend on ActiveRecord, ActionMailer, etc.
